### PR TITLE
Updating CI to CircleCI and Badges to Medology

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 build/
+artifacts/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,20 @@
-sudo: required
+machine:
+  pre:
+    -
+  services:
+    - docker
 
-services:
-  - docker
+dependencies:
+  cache_directories:
+    - "vendor/"
 
-cache:
-  directories:
-    - vendor/
+  override:
+    - docker build circleci/docker/php -t parallel/php:5.6
+    - bin/composer install
 
-addons:
-  code_climate:
-    repo_token: $CODECLIMATE_REPO_TOKEN
+test:
+  override:
+    - ./circleci/bin/php vendor/bin/phpunit --coverage-clover build/logs/clover.xml
 
-install:
-  - docker build travisci/docker/php -t parallel/php:5.6
-  - bin/composer install
-
-script:
-  - ./travisci/bin/php vendor/bin/phpunit --coverage-clover build/logs/clover.xml
-
-after_script:
-  - ./travisci/bin/php vendor/bin/test-reporter
+  post:
+    - ./circleci/bin/php vendor/bin/test-reporter

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Build Status](https://travis-ci.org/TaysirTayyab/phpunit-parallel-runner.svg?branch=master) ![Code Climate](https://codeclimate.com/github/TaysirTayyab/phpunit-parallel-runner/badges/gpa.svg) ![Test Coverage](https://codeclimate.com/github/TaysirTayyab/phpunit-parallel-runner/badges/coverage.svg)
+![Build Status](https://circleci.com/gh/Medology/phpunit-parallel-runner/tree/master.svg?style=shield&circle-token=273717e1bf67e269b52600fdf9f6d894a91b3afd) ![Code Climate](https://codeclimate.com/github/Medology/phpunit-parallel-runner/badges/gpa.svg) ![Test Coverage](https://codeclimate.com/github/Medology/phpunit-parallel-runner/badges/coverage.svg)
 
 # PHPUnit Parallel (Node) Runner
 A parallelizer for running PHPUnit on multiple nodes. While many plugins exist to run PHPUnit in parallel
@@ -7,8 +7,8 @@ _processes_, this extensions allows for running PHPUnit in parallel on multiple 
  
 ## Dependencies
 ### PhpUnit
-- [Version 5](https://github.com/TaysirTayyab/phpunit-parallel-runner)
-- [Version 4](https://github.com/TaysirTayyab/phpunit-parallel-runner/tree/phpunit4)
+- [Version 5](https://github.com/Medology/phpunit-parallel-runner)
+- [Version 4](https://github.com/Medology/phpunit-parallel-runner/tree/phpunit4)
 
 The development environment for this project is configured using docker, removing the need to actually install
 anything on your maching. Simply install the [Docker Engine](https://docs.docker.com/engine/installation/) and

--- a/bin/composer
+++ b/bin/composer
@@ -1,3 +1,8 @@
 #!/bin/bash +x
 
-docker run --rm -v "$(pwd)":/data -w /data composer/composer:1.1 "$@"
+RM='';
+if [ "${CIRCLECI}" != true ] ; then
+  RM=--rm;
+fi
+
+docker run $RM -v "$(pwd)":/data -w /data composer/composer:1.1 "$@"

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,19 @@
+machine:
+  services:
+    - docker
+
+dependencies:
+  cache_directories:
+    - "vendor/"
+
+  override:
+    - docker build -t parallel/php:5.6 ./circleci/docker/php
+    - ./bin/composer install
+
+test:
+  override:
+    - ./circleci/bin/php vendor/bin/phpunit --coverage-clover build/logs/clover.xml --log-junit artifacts/junit.xml
+
+  post:
+    - ./circleci/bin/php vendor/bin/test-reporter
+    - cp artifacts/junit.xml ${CIRCLE_TEST_REPORTS}/phpunit.junit.xml

--- a/circleci/bin/php
+++ b/circleci/bin/php
@@ -1,5 +1,5 @@
 #!/bin/bash +x
 
-docker run --rm -it -v "$(pwd)":/app -w /app \
+docker run -it -v "$(pwd)":/app -w /app \
     -e "CODECLIMATE_REPO_TOKEN=$CODECLIMATE_REPO_TOKEN" \
     parallel/php:5.6 php "$@"

--- a/circleci/docker/php/Dockerfile
+++ b/circleci/docker/php/Dockerfile
@@ -1,3 +1,4 @@
+# code climate coverage reports needs xdebug and the report submitter needs git to work
 FROM php:5.6
 
 RUN yes | pecl install -f xdebug \

--- a/circleci/docker/php/php.ini
+++ b/circleci/docker/php/php.ini
@@ -1,0 +1,1 @@
+date.timezone = "UTC"

--- a/composer.json
+++ b/composer.json
@@ -1,17 +1,13 @@
 {
-    "name": "TaysirTayyab/php-parallel-runner",
+    "name": "medology/phpunit-parallel-runner",
     "type": "library",
-    "description": "Parallel Runner for PHPUnit",
+    "description": "Parallel (Node) Runner for PHPUnit",
+    "keywords": ["phpunit", "xunit", "testing", "parallel"],
+    "homepage": "https://github.com/Medology/phpunit-parallel-runner",
     "license": "MIT",
-    "authors": [
-        {
-            "name": "Taysir Tayyab",
-            "role": "Developer"
-        }
-    ],
     "support": {
-        "issues": "http://github.com/TaysirTayyab/phpunit-parallel-runner/issues",
-        "source": "https://github.com/TaysirTayyab/phpunit-parallel-runner"
+        "issues": "http://github.com/Medology/phpunit-parallel-runner/issues",
+        "source": "https://github.com/Medology/phpunit-parallel-runner"
     },
     "require": {
         "php": ">=5.6",

--- a/phpunit-parallel
+++ b/phpunit-parallel
@@ -25,11 +25,17 @@ if (!ini_get('date.timezone')) {
     ini_set('date.timezone', 'UTC');
 }
 
-$file = __DIR__ . '/vendor/autoload.php';
-if (file_exists($file)) {
-    define('PHPUNIT_COMPOSER_INSTALL', $file);
-    unset($file);
-} else {
+foreach (array(__DIR__ . '/../../autoload.php', __DIR__ . '/../vendor/autoload.php', __DIR__ . '/vendor/autoload.php') as $file) {
+    if (file_exists($file)) {
+        define('PHPUNIT_COMPOSER_INSTALL', $file);
+
+        break;
+    }
+}
+
+unset($file);
+
+if (!defined('PHPUNIT_COMPOSER_INSTALL')) {
     fwrite(STDERR,
         'You need to set up the project dependencies using the following commands:' . PHP_EOL .
         'wget http://getcomposer.org/composer.phar' . PHP_EOL .

--- a/travisci/docker/php/php.ini
+++ b/travisci/docker/php/php.ini
@@ -1,1 +1,0 @@
-date.timezone = "UTC"


### PR DESCRIPTION
# Overview

This fork was set up to run with TravisCI against @TaysirTayyab's account. We need to move this to CircleCI and get it set up against @Medology's account.

# Changes
- moving `travisci/` to `circleci/`
- updating `.travis.yml` to `circle.yml` with appropriate structure changes
- updating `README.md` to use Medology's badges, instead of mine