### PR TITLE
Fixing Parallel and Filter Bug (PHPUnit4)

### DIFF
--- a/bin/phpunit
+++ b/bin/phpunit
@@ -1,5 +1,6 @@
-#!/bin/bash +x
+#!/bin/bash -x
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-(cd "$ROOT" && bin/php vendor/bin/phpunit "$@")
+cd "$ROOT"
+bin/php vendor/bin/phpunit "$@"

--- a/bin/phpunit
+++ b/bin/phpunit
@@ -1,3 +1,5 @@
 #!/bin/bash +x
 
-php vendor/bin/phpunit "$@"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+(cd "$ROOT" && bin/php vendor/bin/phpunit "$@")

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,12 +9,19 @@
          beStrictAboutTodoAnnotatedTests="true"
          verbose="true">
     <testsuite>
-        <directory suffix="Test.php">tests</directory>
+        <directory>./tests/</directory>
     </testsuite>
 
     <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
+        <whitelist>
+            <directory>./src</directory>
+            <exclude>
+                    <directory>./vendor</directory>
+                    <directory>./tests</directory>
+                    <directory>./circleci</directory>
+                    <directory>./bin</directory>
+                    <directory>./.idea</directory>
+            </exclude>
         </whitelist>
     </filter>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,7 +9,8 @@
          beStrictAboutTodoAnnotatedTests="true"
          verbose="true">
     <testsuite>
-        <directory>./tests/</directory>
+        <directory suffix=".php">./tests/</directory>
+        <directory suffix=".phpt">./tests/</directory>
     </testsuite>
 
     <filter>

--- a/src/ParallelUI/PHPUnit_Parallel_TestRunner.php
+++ b/src/ParallelUI/PHPUnit_Parallel_TestRunner.php
@@ -2,6 +2,7 @@
 
 use PHPUnit_Runner_Filter_Factory;
 use PHPUnit_TextUI_TestRunner;
+use PHPUnit_Framework_Test;
 use PHPUnit_Framework_TestSuite;
 use ReflectionClass;
 
@@ -20,7 +21,7 @@ class PHPUnit_Parallel_TestRunner extends PHPUnit_TextUI_TestRunner
      */
     private function processSuiteFilters(PHPUnit_Framework_TestSuite $suite, array $arguments)
     {
-        if (!$arguments['filter'] &&
+        if (empty($arguments['filter']) &&
             empty($arguments[self::PARALLEL_ARG]) &&
             empty($arguments['groups']) &&
             empty($arguments['excludeGroups'])) {
@@ -43,14 +44,14 @@ class PHPUnit_Parallel_TestRunner extends PHPUnit_TextUI_TestRunner
             );
         }
 
-        if ($arguments['filter']) {
+        if (!empty($arguments['filter'])) {
             $filterFactory->addFilter(
                 new ReflectionClass('PHPUnit_Runner_Filter_Test'),
                 $arguments['filter']
             );
         }
 
-        if ($arguments[self::PARALLEL_ARG]) {
+        if (!empty($arguments[self::PARALLEL_ARG])) {
             $filterFactory->addFilter(
                 new ReflectionClass('PhpUnit\Runner\Filter\Parallel'),
                 $arguments[self::PARALLEL_ARG]
@@ -63,7 +64,7 @@ class PHPUnit_Parallel_TestRunner extends PHPUnit_TextUI_TestRunner
     /**
      * {@inheritdoc}
      */
-    public function doRun(PHPUnit_Framework_TestSuite $suite, array $arguments = [], $exit = true)
+    public function doRun(PHPUnit_Framework_Test $suite, array $arguments = array())
     {
         $this->processSuiteFilters($suite, $arguments);
 

--- a/src/Runner/Filter/Parallel.php
+++ b/src/Runner/Filter/Parallel.php
@@ -8,7 +8,7 @@ use RecursiveFilterIterator;
 class Parallel extends RecursiveFilterIterator {
     private $THIS_NODE;
     private $TOTAL_NODES;
-    private static $counter = 0;
+    private static $counter;
 
     /**
      * {@inheritdoc}
@@ -16,7 +16,9 @@ class Parallel extends RecursiveFilterIterator {
     public function __construct(RecursiveIterator $iterator, $filter)
     {
         parent::__construct($iterator);
+
         $this->setFilter($filter[0], $filter[1]);
+        self::$counter = 0;
     }
 
     /**
@@ -48,9 +50,9 @@ class Parallel extends RecursiveFilterIterator {
             return true;
         }
 
-        $mod = (self::$counter - $this->THIS_NODE) % $this->TOTAL_NODES;
+        $mod = (int)(self::$counter - $this->THIS_NODE) % $this->TOTAL_NODES;
         self::$counter++;
 
-        return ($mod == 0);
+        return ($mod === 0);
     }
 }

--- a/tests/Runner/Filter/ParallelTest_basic.phpt
+++ b/tests/Runner/Filter/ParallelTest_basic.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Test Parallel Filter when No Args Provided
+--FILE--
+<?php
+use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
+
+// $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][3] = __DIR__ . '/_files/BasicTestFile.php';
+
+$dir = $_SERVER['PWD'];
+require_once($dir . '/vendor/autoload.php');
+
+PHPUnit_Parallel_Command::main();
+
+--EXPECTF--
+TAP version %s
+ok 1 - BasicTest::testBasic1
+ok 2 - BasicTest::testBasic2
+ok 3 - BasicTest::testBasic3
+ok 4 - BasicTest::testBasic4
+ok 5 - BasicTest::testBasic5
+ok 6 - BasicTest::testBasic6
+ok 7 - BasicTest::testBasic7
+ok 8 - BasicTest::testBasic8
+ok 9 - BasicTest::testBasic9
+ok 10 - BasicTest::testBasic10
+ok 11 - BasicTest::testBasic11
+ok 12 - BasicTest::testBasic12
+1..12

--- a/tests/Runner/Filter/ParallelTest_error.phpt
+++ b/tests/Runner/Filter/ParallelTest_error.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Test Parallel Filter for Invalid Values
+--FILE--
+<?php
+use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
+
+// $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][3] = '--current-node=1';
+$_SERVER['argv'][4] = '--total-nodes=1';
+$_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
+
+$dir = $_SERVER['PWD'];
+require_once($dir . '/vendor/autoload.php');
+
+try {
+    PHPUnit_Parallel_Command::main(false);
+} catch (InvalidArgumentException $e) {
+    echo $e->getMessage();
+}
+
+--EXPECTF--
+TAP version %s
+Current node must be greater than or equal to 0, but less than or equal to total nodes!

--- a/tests/Runner/Filter/ParallelTest_variation_node2-1.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node2-1.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Test Parallel Filter for 1st of 2 Nodes
+--FILE--
+<?php
+use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
+
+// $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][3] = '--current-node=0';
+$_SERVER['argv'][4] = '--total-nodes=2';
+$_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
+
+$dir = $_SERVER['PWD'];
+require_once($dir . '/vendor/autoload.php');
+
+PHPUnit_Parallel_Command::main();
+
+--EXPECTF--
+TAP version %s
+ok 1 - BasicTest::testBasic1
+ok 2 - BasicTest::testBasic3
+ok 3 - BasicTest::testBasic5
+ok 4 - BasicTest::testBasic7
+ok 5 - BasicTest::testBasic9
+ok 6 - BasicTest::testBasic11
+1..6

--- a/tests/Runner/Filter/ParallelTest_variation_node2-2.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node2-2.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Test Parallel Filter for 2nd of 2 Nodes
+--FILE--
+<?php
+use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
+
+// $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][3] = '--current-node=1';
+$_SERVER['argv'][4] = '--total-nodes=2';
+$_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
+
+$dir = $_SERVER['PWD'];
+require_once($dir . '/vendor/autoload.php');
+
+PHPUnit_Parallel_Command::main();
+
+--EXPECTF--
+TAP version %s
+ok 1 - BasicTest::testBasic2
+ok 2 - BasicTest::testBasic4
+ok 3 - BasicTest::testBasic6
+ok 4 - BasicTest::testBasic8
+ok 5 - BasicTest::testBasic10
+ok 6 - BasicTest::testBasic12
+1..6

--- a/tests/Runner/Filter/ParallelTest_variation_node3-1.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node3-1.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Test Parallel Filter for 1st of 3 Nodes
+--FILE--
+<?php
+use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
+
+// $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][3] = '--current-node=0';
+$_SERVER['argv'][4] = '--total-nodes=3';
+$_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
+
+$dir = $_SERVER['PWD'];
+require_once($dir . '/vendor/autoload.php');
+
+PHPUnit_Parallel_Command::main();
+
+--EXPECTF--
+TAP version %s
+ok 1 - BasicTest::testBasic1
+ok 2 - BasicTest::testBasic4
+ok 3 - BasicTest::testBasic7
+ok 4 - BasicTest::testBasic10
+1..4

--- a/tests/Runner/Filter/ParallelTest_variation_node3-2.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node3-2.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Test Parallel Filter for 2nd of 3 Nodes
+--FILE--
+<?php
+use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
+
+// $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][3] = '--current-node=1';
+$_SERVER['argv'][4] = '--total-nodes=3';
+$_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
+
+$dir = $_SERVER['PWD'];
+require_once($dir . '/vendor/autoload.php');
+
+PHPUnit_Parallel_Command::main();
+
+--EXPECTF--
+TAP version %s
+ok 1 - BasicTest::testBasic2
+ok 2 - BasicTest::testBasic5
+ok 3 - BasicTest::testBasic8
+ok 4 - BasicTest::testBasic11
+1..4

--- a/tests/Runner/Filter/ParallelTest_variation_node3-3.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node3-3.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Test Parallel Filter for 3rd of 3 Nodes
+--FILE--
+<?php
+use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
+
+// $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][3] = '--current-node=2';
+$_SERVER['argv'][4] = '--total-nodes=3';
+$_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
+
+$dir = $_SERVER['PWD'];
+require_once($dir . '/vendor/autoload.php');
+
+PHPUnit_Parallel_Command::main();
+
+--EXPECTF--
+TAP version %s
+ok 1 - BasicTest::testBasic3
+ok 2 - BasicTest::testBasic6
+ok 3 - BasicTest::testBasic9
+ok 4 - BasicTest::testBasic12
+1..4

--- a/tests/Runner/Filter/ParallelTest_variation_node5-1.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node5-1.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Test Parallel Filter for 1st of 5 Nodes
+--FILE--
+<?php
+use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
+
+// $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][3] = '--current-node=0';
+$_SERVER['argv'][4] = '--total-nodes=5';
+$_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
+
+$dir = $_SERVER['PWD'];
+require_once($dir . '/vendor/autoload.php');
+
+PHPUnit_Parallel_Command::main();
+
+--EXPECTF--
+TAP version %s
+ok 1 - BasicTest::testBasic1
+ok 2 - BasicTest::testBasic6
+ok 3 - BasicTest::testBasic11
+1..3

--- a/tests/Runner/Filter/ParallelTest_variation_node5-2.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node5-2.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Test Parallel Filter for 2nd of 5 Nodes
+--FILE--
+<?php
+use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
+
+// $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][3] = '--current-node=1';
+$_SERVER['argv'][4] = '--total-nodes=5';
+$_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
+
+$dir = $_SERVER['PWD'];
+require_once($dir . '/vendor/autoload.php');
+
+PHPUnit_Parallel_Command::main();
+
+--EXPECTF--
+TAP version %s
+ok 1 - BasicTest::testBasic2
+ok 2 - BasicTest::testBasic7
+ok 3 - BasicTest::testBasic12
+1..3

--- a/tests/Runner/Filter/ParallelTest_variation_node5-3.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node5-3.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test Parallel Filter for 3rd of 5 Nodes
+--FILE--
+<?php
+use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
+
+// $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][3] = '--current-node=2';
+$_SERVER['argv'][4] = '--total-nodes=5';
+$_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
+
+$dir = $_SERVER['PWD'];
+require_once($dir . '/vendor/autoload.php');
+
+PHPUnit_Parallel_Command::main();
+
+--EXPECTF--
+TAP version %s
+ok 1 - BasicTest::testBasic3
+ok 2 - BasicTest::testBasic8
+1..2

--- a/tests/Runner/Filter/ParallelTest_variation_node5-4.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node5-4.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test Parallel Filter for 4th of 5 Nodes
+--FILE--
+<?php
+use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
+
+// $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][3] = '--current-node=3';
+$_SERVER['argv'][4] = '--total-nodes=5';
+$_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
+
+$dir = $_SERVER['PWD'];
+require_once($dir . '/vendor/autoload.php');
+
+PHPUnit_Parallel_Command::main();
+
+--EXPECTF--
+TAP version %s
+ok 1 - BasicTest::testBasic4
+ok 2 - BasicTest::testBasic9
+1..2

--- a/tests/Runner/Filter/ParallelTest_variation_node5-5.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node5-5.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test Parallel Filter for 5th of 5 Nodes
+--FILE--
+<?php
+use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
+
+// $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][3] = '--current-node=4';
+$_SERVER['argv'][4] = '--total-nodes=5';
+$_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
+
+$dir = $_SERVER['PWD'];
+require_once($dir . '/vendor/autoload.php');
+
+PHPUnit_Parallel_Command::main();
+
+--EXPECTF--
+TAP version %s
+ok 1 - BasicTest::testBasic5
+ok 2 - BasicTest::testBasic10
+1..2

--- a/tests/Runner/Filter/ParallelTest_variation_node7-1.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-1.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test Parallel Filter for 1st of 7 Nodes
+--FILE--
+<?php
+use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
+
+// $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][3] = '--current-node=0';
+$_SERVER['argv'][4] = '--total-nodes=7';
+$_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
+
+$dir = $_SERVER['PWD'];
+require_once($dir . '/vendor/autoload.php');
+
+PHPUnit_Parallel_Command::main();
+
+--EXPECTF--
+TAP version %s
+ok 1 - BasicTest::testBasic1
+ok 2 - BasicTest::testBasic8
+1..2

--- a/tests/Runner/Filter/ParallelTest_variation_node7-2.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-2.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test Parallel Filter for 2nd of 7 Nodes
+--FILE--
+<?php
+use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
+
+// $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][3] = '--current-node=1';
+$_SERVER['argv'][4] = '--total-nodes=7';
+$_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
+
+$dir = $_SERVER['PWD'];
+require_once($dir . '/vendor/autoload.php');
+
+PHPUnit_Parallel_Command::main();
+
+--EXPECTF--
+TAP version %s
+ok 1 - BasicTest::testBasic2
+ok 2 - BasicTest::testBasic9
+1..2

--- a/tests/Runner/Filter/ParallelTest_variation_node7-3.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-3.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test Parallel Filter for 3rd of 7 Nodes
+--FILE--
+<?php
+use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
+
+// $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][3] = '--current-node=2';
+$_SERVER['argv'][4] = '--total-nodes=7';
+$_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
+
+$dir = $_SERVER['PWD'];
+require_once($dir . '/vendor/autoload.php');
+
+PHPUnit_Parallel_Command::main();
+
+--EXPECTF--
+TAP version %s
+ok 1 - BasicTest::testBasic3
+ok 2 - BasicTest::testBasic10
+1..2

--- a/tests/Runner/Filter/ParallelTest_variation_node7-4.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-4.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test Parallel Filter for 4th of 7 Nodes
+--FILE--
+<?php
+use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
+
+// $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][3] = '--current-node=3';
+$_SERVER['argv'][4] = '--total-nodes=7';
+$_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
+
+$dir = $_SERVER['PWD'];
+require_once($dir . '/vendor/autoload.php');
+
+PHPUnit_Parallel_Command::main();
+
+--EXPECTF--
+TAP version %s
+ok 1 - BasicTest::testBasic4
+ok 2 - BasicTest::testBasic11
+1..2

--- a/tests/Runner/Filter/ParallelTest_variation_node7-5.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-5.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test Parallel Filter for 5th of 7 Nodes
+--FILE--
+<?php
+use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
+
+// $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][3] = '--current-node=4';
+$_SERVER['argv'][4] = '--total-nodes=7';
+$_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
+
+$dir = $_SERVER['PWD'];
+require_once($dir . '/vendor/autoload.php');
+
+PHPUnit_Parallel_Command::main();
+
+--EXPECTF--
+TAP version %s
+ok 1 - BasicTest::testBasic5
+ok 2 - BasicTest::testBasic12
+1..2

--- a/tests/Runner/Filter/ParallelTest_variation_node7-6.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-6.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Test Parallel Filter for 6th of 7 Nodes
+--FILE--
+<?php
+use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
+
+// $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][3] = '--current-node=5';
+$_SERVER['argv'][4] = '--total-nodes=7';
+$_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
+
+$dir = $_SERVER['PWD'];
+require_once($dir . '/vendor/autoload.php');
+
+PHPUnit_Parallel_Command::main();
+
+--EXPECTF--
+TAP version %s
+ok 1 - BasicTest::testBasic6
+1..1

--- a/tests/Runner/Filter/ParallelTest_variation_node7-7.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-7.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Test Parallel Filter for 7th of 7 Nodes
+--FILE--
+<?php
+use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
+
+// $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
+$_SERVER['argv'][1] = '--no-configuration';
+$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][3] = '--current-node=6';
+$_SERVER['argv'][4] = '--total-nodes=7';
+$_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
+
+$dir = $_SERVER['PWD'];
+require_once($dir . '/vendor/autoload.php');
+
+PHPUnit_Parallel_Command::main();
+
+--EXPECTF--
+TAP version %s
+ok 1 - BasicTest::testBasic7
+1..1

--- a/tests/Runner/Filter/_files/BasicTestFile.php
+++ b/tests/Runner/Filter/_files/BasicTestFile.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * Class BasicTest.
+ *
+ * Long
+ */
+class BasicTest extends \PHPUnit_Framework_TestCase
+{
+    public function testBasic1()
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testBasic2()
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testBasic3()
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testBasic4()
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testBasic5()
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testBasic6()
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testBasic7()
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testBasic8()
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testBasic9()
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testBasic10()
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testBasic11()
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testBasic12()
+    {
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
# Overview

Fixes two main bugs and one minor:
1. Script if parallelization options are provided without the `filter` option
2. Script does not parallelize tests like you would think it does (it does parallelize, just not the right tests)
3. Fixes PHP warning that `Parallel_TestRunner::doRun` function header did not match that of the base class.

# Changes
- `phpunit.xml` updated to support better code exclusion for code climate
- `bin/phpunit` not tries to use docker php container by default
- lots of unit tests for the filter