### PR TITLE
Adding Return Value to Runner

### DIFF
--- a/src/ParallelUI/PHPUnit_Parallel_TestRunner.php
+++ b/src/ParallelUI/PHPUnit_Parallel_TestRunner.php
@@ -68,6 +68,6 @@ class PHPUnit_Parallel_TestRunner extends PHPUnit_TextUI_TestRunner
     {
         $this->processSuiteFilters($suite, $arguments);
 
-        call_user_func_array(['parent', 'doRun'], func_get_args());
+        return call_user_func_array(['parent', 'doRun'], func_get_args());
     }
 }


### PR DESCRIPTION
# Overview

The runner was not extended correctly, with `PHPUnit_ParallelUI_TestRunner->doRun` not returning any values. As a result, the script `phpunit-parallel` would always return a value of 2 on success instead of 0.

# Cause
`TextUI\TestRunner->doRun` returns the results of the test. When the parallel runner was extended, we weren't returning this result meaning the `Command` class was thinking there was no result and exiting with a code of 2 (for Unknown Exception).

# Changes
Have the parallel runner return the results from the parent runner.