### PR TITLE
force circleci to fetch the origin

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ dependencies:
     - "vendor/"
 
   override:
-    - git config --global user.email "ci@medology.com" && git config --global user.name "Circle CI" && git rebase origin/master
+    - git fetch origin;git config --global user.email "ci@medology.com" && git config --global user.name "Circle CI" && git rebase origin/master
     - docker build -t parallel/php:5.6 ./circleci/docker/php
     - ./bin/composer install
 


### PR DESCRIPTION
For https://github.com/Medology/stdcheck.com/issues/2039

When rebuild the circle ci, it will try to use the cache. So this PR will force it to fetch the origin again.