### PR TITLE
Fix issue that test is not distributed evenly

### DIFF
--- a/src/Runner/Filter/Parallel.php
+++ b/src/Runner/Filter/Parallel.php
@@ -1,6 +1,8 @@
 <?php namespace PhpUnit\Runner\Filter;
 
 use InvalidArgumentException;
+use PHPUnit_Framework_Test;
+use PHPUnit_Framework_TestCase;
 use PHPUnit_Framework_TestSuite;
 use RecursiveIterator;
 use RecursiveFilterIterator;
@@ -8,7 +10,7 @@ use RecursiveFilterIterator;
 class Parallel extends RecursiveFilterIterator {
     private $THIS_NODE;
     private $TOTAL_NODES;
-    private static $counter;
+    private static $counter = 0;
 
     /**
      * {@inheritdoc}
@@ -18,7 +20,6 @@ class Parallel extends RecursiveFilterIterator {
         parent::__construct($iterator);
 
         $this->setFilter($filter[0], $filter[1]);
-        self::$counter = 0;
     }
 
     /**

--- a/tests/Runner/Filter/ParallelTest_variation_node5-1.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node5-1.phpt
@@ -18,7 +18,7 @@ PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
 TAP version %s
-ok 1 - BasicTest::testBasic1
-ok 2 - BasicTest::testBasic6
-ok 3 - BasicTest::testBasic11
+ok 1 - BasicTest::testBasic2
+ok 2 - BasicTest::testBasic7
+ok 3 - BasicTest::testBasic12
 1..3

--- a/tests/Runner/Filter/ParallelTest_variation_node5-2.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node5-2.phpt
@@ -18,7 +18,6 @@ PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
 TAP version %s
-ok 1 - BasicTest::testBasic2
-ok 2 - BasicTest::testBasic7
-ok 3 - BasicTest::testBasic12
-1..3
+ok 1 - BasicTest::testBasic3
+ok 2 - BasicTest::testBasic8
+1..2

--- a/tests/Runner/Filter/ParallelTest_variation_node5-3.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node5-3.phpt
@@ -18,6 +18,6 @@ PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
 TAP version %s
-ok 1 - BasicTest::testBasic3
-ok 2 - BasicTest::testBasic8
+ok 1 - BasicTest::testBasic4
+ok 2 - BasicTest::testBasic9
 1..2

--- a/tests/Runner/Filter/ParallelTest_variation_node5-4.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node5-4.phpt
@@ -18,6 +18,6 @@ PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
 TAP version %s
-ok 1 - BasicTest::testBasic4
-ok 2 - BasicTest::testBasic9
+ok 1 - BasicTest::testBasic5
+ok 2 - BasicTest::testBasic10
 1..2

--- a/tests/Runner/Filter/ParallelTest_variation_node5-5.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node5-5.phpt
@@ -18,6 +18,7 @@ PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
 TAP version %s
-ok 1 - BasicTest::testBasic5
-ok 2 - BasicTest::testBasic10
-1..2
+ok 1 - BasicTest::testBasic1
+ok 2 - BasicTest::testBasic6
+ok 3 - BasicTest::testBasic11
+1..3

--- a/tests/Runner/Filter/ParallelTest_variation_node7-1.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-1.phpt
@@ -18,6 +18,6 @@ PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
 TAP version %s
-ok 1 - BasicTest::testBasic1
-ok 2 - BasicTest::testBasic8
+ok 1 - BasicTest::testBasic5
+ok 2 - BasicTest::testBasic12
 1..2

--- a/tests/Runner/Filter/ParallelTest_variation_node7-2.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-2.phpt
@@ -18,6 +18,5 @@ PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
 TAP version %s
-ok 1 - BasicTest::testBasic2
-ok 2 - BasicTest::testBasic9
-1..2
+ok 1 - BasicTest::testBasic6
+1..1

--- a/tests/Runner/Filter/ParallelTest_variation_node7-3.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-3.phpt
@@ -18,6 +18,5 @@ PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
 TAP version %s
-ok 1 - BasicTest::testBasic3
-ok 2 - BasicTest::testBasic10
-1..2
+ok 1 - BasicTest::testBasic7
+1..1

--- a/tests/Runner/Filter/ParallelTest_variation_node7-4.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-4.phpt
@@ -18,6 +18,6 @@ PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
 TAP version %s
-ok 1 - BasicTest::testBasic4
-ok 2 - BasicTest::testBasic11
+ok 1 - BasicTest::testBasic1
+ok 2 - BasicTest::testBasic8
 1..2

--- a/tests/Runner/Filter/ParallelTest_variation_node7-5.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-5.phpt
@@ -18,6 +18,6 @@ PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
 TAP version %s
-ok 1 - BasicTest::testBasic5
-ok 2 - BasicTest::testBasic12
+ok 1 - BasicTest::testBasic2
+ok 2 - BasicTest::testBasic9
 1..2

--- a/tests/Runner/Filter/ParallelTest_variation_node7-6.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-6.phpt
@@ -18,5 +18,6 @@ PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
 TAP version %s
-ok 1 - BasicTest::testBasic6
-1..1
+ok 1 - BasicTest::testBasic3
+ok 2 - BasicTest::testBasic10
+1..2

--- a/tests/Runner/Filter/ParallelTest_variation_node7-7.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-7.phpt
@@ -18,5 +18,6 @@ PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
 TAP version %s
-ok 1 - BasicTest::testBasic7
-1..1
+ok 1 - BasicTest::testBasic4
+ok 2 - BasicTest::testBasic11
+1..2


### PR DESCRIPTION
For https://github.com/Medology/stdcheck.com/issues/7036

### Issue
Php unit test is not distributed evenly on circleci

### Cause
the static member which is supposed to be shared getting reset every time the class instantiated, which makes it a local counter instead of global counter

### Fix
Remove the static member reset.