### PR TITLE
Update to support and use at least PHPUnit 7.5 and PHP 7.1.30

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,14 +30,14 @@ commands:
             bin/init_project
       - run:
           name: Unit tests
-          command: phpunit --log-junit artifacts/phpunit.junit.xml --report-useless-tests --strict-coverage
+          command: phpunit --log-junit artifacts/phpunit.junit.xml --strict-coverage
       - store_test_results:
           path: artifacts
       - store_artifacts:
           path: artifacts
 
 jobs:
-  test:
+  test-php7.1:
     working_directory: /tmp/phpunit-parallel-runner
     parallelism: 1
     machine:
@@ -49,7 +49,7 @@ jobs:
       - prep
       - test
 
-  test-php5:
+  test-php7.2:
     working_directory: /tmp/phpunit-parallel-runner
     parallelism: 1
     machine:
@@ -60,8 +60,23 @@ jobs:
     steps:
       - prep
       - run:
-          name: Switch image definitions to PHP 5
-          command: rm bin/lib/images.sh && mv bin/lib/images-php5.sh bin/lib/images.sh
+          name: Switch image definitions to PHP 7.2
+          command: rm bin/lib/images.sh && mv bin/lib/images-php7.2.sh bin/lib/images.sh
+      - test
+
+  test-php7.3:
+    working_directory: /tmp/phpunit-parallel-runner
+    parallelism: 1
+    machine:
+      enabled: true
+    environment:
+      - PATH: /opt/circleci/.pyenv/shims:./bin:./node_modules/.bin:./vendor/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+    steps:
+      - prep
+      - run:
+          name: Switch image definitions to PHP 7.3
+          command: rm bin/lib/images.sh && mv bin/lib/images-php7.3.sh bin/lib/images.sh
       - test
 
 workflows:
@@ -69,4 +84,5 @@ workflows:
   test:
     jobs:
       - test
-      - test-php5
+      - test-php7.2
+      - test-php7.3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ commands:
           path: artifacts
 
 jobs:
-  test-php7.1:
+  test-php7-1:
     working_directory: /tmp/phpunit-parallel-runner
     parallelism: 1
     machine:
@@ -49,7 +49,7 @@ jobs:
       - prep
       - test
 
-  test-php7.2:
+  test-php7-2:
     working_directory: /tmp/phpunit-parallel-runner
     parallelism: 1
     machine:
@@ -64,7 +64,7 @@ jobs:
           command: rm bin/lib/images.sh && mv bin/lib/images-php7.2.sh bin/lib/images.sh
       - test
 
-  test-php7.3:
+  test-php7-3:
     working_directory: /tmp/phpunit-parallel-runner
     parallelism: 1
     machine:
@@ -83,6 +83,6 @@ workflows:
   version: 2
   test:
     jobs:
-      - test
-      - test-php7.2
-      - test-php7.3
+      - test-php7-1
+      - test-php7-2
+      - test-php7-3

--- a/bin/lib/images-php7.2.sh
+++ b/bin/lib/images-php7.2.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+export PHP_ACCOUNT=chekote
+export PHP_REPO=php
+export PHP_TAG=7.2.19.a-phpunit7

--- a/bin/lib/images-php7.3.sh
+++ b/bin/lib/images-php7.3.sh
@@ -2,4 +2,4 @@
 
 export PHP_ACCOUNT=chekote
 export PHP_REPO=php
-export PHP_TAG=5.6.40-phpunit5
+export PHP_TAG=7.3.6.a-phpunit7

--- a/bin/lib/images.sh
+++ b/bin/lib/images.sh
@@ -2,4 +2,4 @@
 
 export PHP_ACCOUNT=chekote
 export PHP_REPO=php
-export PHP_TAG=7.2.14-phpunit5
+export PHP_TAG=7.1.30.a-phpunit7

--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,11 @@
         "classmap" : [
             "src/Runner"
         ]
+    },
+    "autoload-dev": {
+        "psr-4": { "CustomPrinter\\": "tests/Printer" }
+    },
+    "require-dev": {
+        "symfony/yaml": "^4.3"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
         "source": "https://github.com/Medology/phpunit-parallel-runner"
     },
     "require": {
-        "php": "7.1.30",
+        "php": ">=7.1",
         "phpunit/phpunit": "~7.5"
     },
     "config": {
         "platform": {
-            "php": "7.1.30"
+            "php": ">=7.1"
         }
     },
     "bin": [

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
         "source": "https://github.com/Medology/phpunit-parallel-runner"
     },
     "require": {
-        "php": ">=5.6",
-        "phpunit/phpunit": "~5.7"
+        "php": "7.1.30",
+        "phpunit/phpunit": "~7.5"
     },
     "config": {
         "platform": {
-            "php": "5.6"
+            "php": "7.1.30"
         }
     },
     "bin": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,36 +4,38 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "21a4324977fd848892028e96e8182a0b",
+    "content-hash": "4b8afef561fb625797aef77d1e30111b",
     "packages": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.0.5",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/a2c590166b2133a4633738648b6b064edae0814a",
+                "reference": "a2c590166b2133a4633738648b6b064edae0814a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3,<8.0-DEV"
+                "php": "^7.1"
             },
             "require-dev": {
-                "athletic/athletic": "~0.1.8",
+                "doctrine/coding-standard": "^6.0",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
+                "phpbench/phpbench": "^0.13",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-shim": "^0.11",
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -53,34 +55,37 @@
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://github.com/doctrine/instantiator",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
             "keywords": [
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14T21:17:01+00:00"
+            "time": "2019-03-17T17:37:11+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.7.0",
+            "version": "1.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
+                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
+                "reference": "e6828efaba2c9b79f4499dae1d66ef8bfa7b2b72",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.1"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
             },
             "require-dev": {
                 "doctrine/collections": "^1.0",
                 "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^4.1"
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "autoload": {
@@ -103,7 +108,109 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-10-19T19:58:43+00:00"
+            "time": "2019-04-07T13:18:21+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^2.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "role": "Developer",
+                    "email": "arne@blankerts.de"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "role": "Developer",
+                    "email": "sebastian@phpeople.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "role": "Developer",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "time": "2018-07-08T19:23:20+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "role": "Developer",
+                    "email": "arne@blankerts.de"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "role": "Developer",
+                    "email": "sebastian@phpeople.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "role": "Developer",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "time": "2018-07-08T19:19:57+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -161,29 +268,35 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.3.2",
+            "version": "4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2"
+                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bf329f6c1aadea3299f08ee804682b7c45b326a2",
-                "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
+                "reference": "bdd9f737ebc2a01c06ea7ff4308ec6697db9b53c",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0",
+                "php": "^7.0",
                 "phpdocumentor/reflection-common": "^1.0.0",
                 "phpdocumentor/type-resolver": "^0.4.0",
                 "webmozart/assert": "^1.0"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.4"
+                "doctrine/instantiator": "~1.0.5",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^6.4"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "phpDocumentor\\Reflection\\": [
@@ -202,7 +315,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-10T14:09:06+00:00"
+            "time": "2019-04-30T17:48:53+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -253,16 +366,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.8.0",
+            "version": "1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06"
+                "reference": "1927e75f4ed19131ec9bcc3b002e07fb1173ee76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
-                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/1927e75f4ed19131ec9bcc3b002e07fb1173ee76",
+                "reference": "1927e75f4ed19131ec9bcc3b002e07fb1173ee76",
                 "shasum": ""
             },
             "require": {
@@ -283,8 +396,8 @@
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Prophecy\\": "src/"
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -312,44 +425,44 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-08-05T17:53:17+00:00"
+            "time": "2019-06-13T12:50:23+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "4.0.8",
+            "version": "6.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d"
+                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
-                "reference": "ef7b2f56815df854e66ceaee8ebe9393ae36a40d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
+                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^5.6 || ^7.0",
-                "phpunit/php-file-iterator": "^1.3",
-                "phpunit/php-text-template": "^1.2",
-                "phpunit/php-token-stream": "^1.4.2 || ^2.0",
-                "sebastian/code-unit-reverse-lookup": "^1.0",
-                "sebastian/environment": "^1.3.2 || ^2.0",
-                "sebastian/version": "^1.0 || ^2.0"
+                "php": "^7.1",
+                "phpunit/php-file-iterator": "^2.0",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^3.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^3.1 || ^4.0",
+                "sebastian/version": "^2.0.1",
+                "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
-                "ext-xdebug": "^2.1.4",
-                "phpunit/phpunit": "^5.7"
+                "phpunit/phpunit": "^7.0"
             },
             "suggest": {
-                "ext-xdebug": "^2.5.1"
+                "ext-xdebug": "^2.6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0.x-dev"
+                    "dev-master": "6.1-dev"
                 }
             },
             "autoload": {
@@ -364,8 +477,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
@@ -375,29 +488,32 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-04-02T07:44:40+00:00"
+            "time": "2018-10-31T16:06:48+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.5",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
+                "reference": "050bedf145a257b1ff02746c31894800e5122946"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/050bedf145a257b1ff02746c31894800e5122946",
+                "reference": "050bedf145a257b1ff02746c31894800e5122946",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -412,8 +528,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "FilterIterator implementation that filters files based on a list of suffixes.",
@@ -422,7 +538,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2017-11-27T13:52:08+00:00"
+            "time": "2018-09-13T20:33:42+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -467,28 +583,28 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.9",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/1038454804406b0b5f5f520358e78c1c2f71501e",
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.1-dev"
                 }
             },
             "autoload": {
@@ -503,8 +619,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Utility class for timing",
@@ -512,33 +628,33 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26T11:10:40+00:00"
+            "time": "2019-06-07T04:22:29+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.12",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16"
+                "reference": "e899757bb3df5ff6e95089132f32cd59aac2220a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/1ce90ba27c42e4e44e6d8458241466380b51fa16",
-                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/e899757bb3df5ff6e95089132f32cd59aac2220a",
+                "reference": "e899757bb3df5ff6e95089132f32cd59aac2220a",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.3.3"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -561,55 +677,57 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-12-04T08:55:13+00:00"
+            "time": "2019-07-25T05:29:42+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "5.7.27",
+            "version": "7.5.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c"
+                "reference": "2834789aeb9ac182ad69bfdf9ae91856a59945ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
-                "reference": "b7803aeca3ccb99ad0a506fa80b64cd6a56bbc0c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2834789aeb9ac182ad69bfdf9ae91856a59945ff",
+                "reference": "2834789aeb9ac182ad69bfdf9ae91856a59945ff",
                 "shasum": ""
             },
             "require": {
+                "doctrine/instantiator": "^1.1",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "~1.3",
-                "php": "^5.6 || ^7.0",
-                "phpspec/prophecy": "^1.6.2",
-                "phpunit/php-code-coverage": "^4.0.4",
-                "phpunit/php-file-iterator": "~1.4",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "^3.2",
-                "sebastian/comparator": "^1.2.4",
-                "sebastian/diff": "^1.4.3",
-                "sebastian/environment": "^1.3.4 || ^2.0",
-                "sebastian/exporter": "~2.0",
-                "sebastian/global-state": "^1.1",
-                "sebastian/object-enumerator": "~2.0",
-                "sebastian/resource-operations": "~1.0",
-                "sebastian/version": "^1.0.6|^2.0.1",
-                "symfony/yaml": "~2.1|~3.0|~4.0"
+                "myclabs/deep-copy": "^1.7",
+                "phar-io/manifest": "^1.0.2",
+                "phar-io/version": "^2.0",
+                "php": "^7.1",
+                "phpspec/prophecy": "^1.7",
+                "phpunit/php-code-coverage": "^6.0.7",
+                "phpunit/php-file-iterator": "^2.0.1",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^2.1",
+                "sebastian/comparator": "^3.0",
+                "sebastian/diff": "^3.0",
+                "sebastian/environment": "^4.0",
+                "sebastian/exporter": "^3.1",
+                "sebastian/global-state": "^2.0",
+                "sebastian/object-enumerator": "^3.0.3",
+                "sebastian/resource-operations": "^2.0",
+                "sebastian/version": "^2.0.1"
             },
             "conflict": {
-                "phpdocumentor/reflection-docblock": "3.0.2"
+                "phpunit/phpunit-mock-objects": "*"
             },
             "require-dev": {
                 "ext-pdo": "*"
             },
             "suggest": {
+                "ext-soap": "*",
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "~1.1"
+                "phpunit/php-invoker": "^2.0"
             },
             "bin": [
                 "phpunit"
@@ -617,7 +735,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.7.x-dev"
+                    "dev-master": "7.5-dev"
                 }
             },
             "autoload": {
@@ -632,8 +750,8 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
+                    "role": "lead",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "The PHP Unit Testing framework.",
@@ -643,67 +761,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-02-01T05:50:59+00:00"
-        },
-        {
-            "name": "phpunit/phpunit-mock-objects",
-            "version": "3.4.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/a23b761686d50a560cc56233b9ecf49597cc9118",
-                "reference": "a23b761686d50a560cc56233b9ecf49597cc9118",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": "^5.6 || ^7.0",
-                "phpunit/php-text-template": "^1.2",
-                "sebastian/exporter": "^1.2 || ^2.0"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<5.4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.4"
-            },
-            "suggest": {
-                "ext-soap": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.2.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Mock Object library for PHPUnit",
-            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
-            "keywords": [
-                "mock",
-                "xunit"
-            ],
-            "abandoned": true,
-            "time": "2017-06-30T09:13:00+00:00"
+            "time": "2019-07-15T06:24:08+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -752,30 +810,30 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.2.4",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be"
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
-                "reference": "2b7424b55f5047b47ac6e5ccb20b2aea4011d9be",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
+                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2 || ~2.0"
+                "php": "^7.1",
+                "sebastian/diff": "^3.0",
+                "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -806,38 +864,39 @@
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
             "keywords": [
                 "comparator",
                 "compare",
                 "equality"
             ],
-            "time": "2017-01-29T09:50:25+00:00"
+            "time": "2018-07-12T15:12:46+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "1.4.3",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4"
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7f066a26a962dbe58ddea9f72a4e82874a3975a4",
-                "reference": "7f066a26a962dbe58ddea9f72a4e82874a3975a4",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^7.5 || ^8.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -862,34 +921,40 @@
             "description": "Diff implementation",
             "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
-                "diff"
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
             ],
-            "time": "2017-05-22T07:24:03+00:00"
+            "time": "2019-02-04T06:01:07+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "2.0.0",
+            "version": "4.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
+                "reference": "f2a2c8e1c97c11ace607a7a667d73d47c19fe404"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
-                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/f2a2c8e1c97c11ace607a7a667d73d47c19fe404",
+                "reference": "f2a2c8e1c97c11ace607a7a667d73d47c19fe404",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.0"
+                "phpunit/phpunit": "^7.5"
+            },
+            "suggest": {
+                "ext-posix": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -914,34 +979,34 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-11-26T07:53:53+00:00"
+            "time": "2019-05-05T09:05:15+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "2.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4"
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
-                "reference": "ce474bdd1a34744d7ac5d6aad3a46d48d9bac4c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/234199f4528de6d12aaa58b612e98f7d36adb937",
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/recursion-context": "~2.0"
+                "php": "^7.0",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.1.x-dev"
                 }
             },
             "autoload": {
@@ -981,27 +1046,27 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-11-19T08:54:04+00:00"
+            "time": "2017-04-03T13:19:02+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "1.1.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -1009,7 +1074,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1032,33 +1097,34 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12T03:26:01+00:00"
+            "time": "2017-04-27T15:39:26+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "2.0.1",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7"
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1311872ac850040a79c3c058bea3e22d0f09cbb7",
-                "reference": "1311872ac850040a79c3c058bea3e22d0f09cbb7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6",
-                "sebastian/recursion-context": "~2.0"
+                "php": "^7.0",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~5"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -1078,32 +1144,77 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-02-18T15:18:39+00:00"
+            "time": "2017-08-03T12:35:26+00:00"
         },
         {
-            "name": "sebastian/recursion-context",
-            "version": "2.0.0",
+            "name": "sebastian/object-reflector",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a"
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/2c3ba150cbec723aa057506e73a8d33bdb286c9a",
-                "reference": "2c3ba150cbec723aa057506e73a8d33bdb286c9a",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2017-03-29T09:07:27+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -1131,29 +1242,29 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-11-19T07:33:16+00:00"
+            "time": "2017-03-03T06:23:57+00:00"
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "1.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6.0"
+                "php": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1173,7 +1284,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28T20:34:47+00:00"
+            "time": "2018-10-04T04:07:39+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1220,16 +1331,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.10.0",
+            "version": "v1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
+                "reference": "550ebaac289296ce228a706d0867afc34687e3f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/550ebaac289296ce228a706d0867afc34687e3f4",
+                "reference": "550ebaac289296ce228a706d0867afc34687e3f4",
                 "shasum": ""
             },
             "require": {
@@ -1241,7 +1352,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.12-dev"
                 }
             },
             "autoload": {
@@ -1258,12 +1369,12 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
                 },
                 {
-                    "name": "Gert de Pagter",
-                    "email": "backendtea@gmail.com"
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -1274,66 +1385,47 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2018-08-06T14:22:27+00:00"
+            "time": "2019-08-06T08:03:45+00:00"
         },
         {
-            "name": "symfony/yaml",
-            "version": "v3.4.23",
+            "name": "theseer/tokenizer",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "57f1ce82c997f5a8701b89ef970e36bb657fd09c"
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/57f1ce82c997f5a8701b89ef970e36bb657fd09c",
-                "reference": "57f1ce82c997f5a8701b89ef970e36bb657fd09c",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/polyfill-ctype": "~1.8"
-            },
-            "conflict": {
-                "symfony/console": "<3.4"
-            },
-            "require-dev": {
-                "symfony/console": "~3.4|~4.0"
-            },
-            "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
+                "classmap": [
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "MIT"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
                 }
             ],
-            "description": "Symfony Yaml Component",
-            "homepage": "https://symfony.com",
-            "time": "2019-02-23T15:06:07+00:00"
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "time": "2019-06-13T22:48:21+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -1387,17 +1479,77 @@
             "time": "2018-12-25T11:19:39+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "symfony/yaml",
+            "version": "v4.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "34d29c2acd1ad65688f58452fd48a46bd996d5a6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/34d29c2acd1ad65688f58452fd48a46bd996d5a6",
+                "reference": "34d29c2acd1ad65688f58452fd48a46bd996d5a6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "symfony/console": "<3.4"
+            },
+            "require-dev": {
+                "symfony/console": "~3.4|~4.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-07-24T14:47:54+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.6"
+        "php": "7.1.30"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "5.6"
+        "php": "7.1.30"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,6 +7,7 @@
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTestsThatDoNotTestAnything="true"
          beStrictAboutTodoAnnotatedTests="true"
+         printerFile="./tests/Printer/TapPrinter.php"
          verbose="true">
     <testsuite>
         <directory suffix=".php">./tests/</directory>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,7 +9,7 @@
          beStrictAboutTodoAnnotatedTests="true"
          printerFile="./tests/Printer/TapPrinter.php"
          verbose="true">
-    <testsuite>
+    <testsuite name="default">
         <directory suffix=".php">./tests/</directory>
         <directory suffix=".phpt">./tests/</directory>
     </testsuite>

--- a/src/ParallelUI/PHPUnit_Parallel_Command.php
+++ b/src/ParallelUI/PHPUnit_Parallel_Command.php
@@ -5,9 +5,6 @@ use PHPUnit\Framework\Exception;
 use PHPUnit\TextUI\Command;
 use PHPUnit\TextUI\TestRunner;
 use PHPUnit\Util\Getopt;
-use PHPUnit_Framework_Exception;
-use PHPUnit_TextUI_Command;
-use PHPUnit_Util_Getopt;
 use RuntimeException;
 
 /**
@@ -15,10 +12,11 @@ use RuntimeException;
  */
 class PHPUnit_Parallel_Command extends Command
 {
-    public function __construct() {
+    public function __construct()
+    {
         $this->longOptions += [
             'current-node=' => null,
-            'total-nodes='  => null,
+            'total-nodes=' => null,
         ];
     }
 
@@ -33,7 +31,7 @@ class PHPUnit_Parallel_Command extends Command
     /**
      * {@inheritdoc}
      */
-    protected function handleArguments(array $argv):void
+    protected function handleArguments(array $argv): void
     {
         try {
             $this->options = Getopt::getopt(
@@ -70,7 +68,7 @@ class PHPUnit_Parallel_Command extends Command
     /**
      * {@inheritdoc}
      */
-    protected function showHelp():void
+    protected function showHelp(): void
     {
         parent::showHelp();
 

--- a/src/ParallelUI/PHPUnit_Parallel_Command.php
+++ b/src/ParallelUI/PHPUnit_Parallel_Command.php
@@ -1,6 +1,10 @@
 <?php namespace PHPUnit\ParallelRunner;
 
 use InvalidArgumentException;
+use PHPUnit\Framework\Exception;
+use PHPUnit\TextUI\Command;
+use PHPUnit\TextUI\TestRunner;
+use PHPUnit\Util\Getopt;
 use PHPUnit_Framework_Exception;
 use PHPUnit_TextUI_Command;
 use PHPUnit_Util_Getopt;
@@ -9,7 +13,7 @@ use RuntimeException;
 /**
  * A Parallel Command runner for CLI
  */
-class PHPUnit_Parallel_Command extends PHPUnit_TextUI_Command
+class PHPUnit_Parallel_Command extends Command
 {
     public function __construct() {
         $this->longOptions += [
@@ -21,7 +25,7 @@ class PHPUnit_Parallel_Command extends PHPUnit_TextUI_Command
     /**
      * {@inheritdoc}
      */
-    protected function createRunner()
+    protected function createRunner(): TestRunner
     {
         return new PHPUnit_Parallel_TestRunner($this->arguments['loader']);
     }
@@ -29,15 +33,15 @@ class PHPUnit_Parallel_Command extends PHPUnit_TextUI_Command
     /**
      * {@inheritdoc}
      */
-    protected function handleArguments(array $argv)
+    protected function handleArguments(array $argv):void
     {
         try {
-            $this->options = PHPUnit_Util_Getopt::getopt(
+            $this->options = Getopt::getopt(
                 $argv,
                 'd:c:hv',
                 array_keys($this->longOptions)
             );
-        } catch (PHPUnit_Framework_Exception $e) {
+        } catch (Exception $e) {
             throw new InvalidArgumentException($e->getMessage());
         }
 
@@ -66,7 +70,7 @@ class PHPUnit_Parallel_Command extends PHPUnit_TextUI_Command
     /**
      * {@inheritdoc}
      */
-    protected function showHelp()
+    protected function showHelp():void
     {
         parent::showHelp();
 

--- a/src/ParallelUI/PHPUnit_Parallel_Command.php
+++ b/src/ParallelUI/PHPUnit_Parallel_Command.php
@@ -8,7 +8,7 @@ use PHPUnit\Util\Getopt;
 use RuntimeException;
 
 /**
- * A Parallel Command runner for CLI
+ * A Parallel Command runner for CLI.
  */
 class PHPUnit_Parallel_Command extends Command
 {
@@ -16,7 +16,7 @@ class PHPUnit_Parallel_Command extends Command
     {
         $this->longOptions += [
             'current-node=' => null,
-            'total-nodes=' => null,
+            'total-nodes='  => null,
         ];
     }
 
@@ -49,16 +49,18 @@ class PHPUnit_Parallel_Command extends Command
             switch ($option[0]) {
                 case '--current-node':
                     $this->arguments[PHPUnit_Parallel_TestRunner::PARALLEL_ARG][0] = $option[1];
+
                     break;
                 case '--total-nodes':
                     $this->arguments[PHPUnit_Parallel_TestRunner::PARALLEL_ARG][1] = $option[1];
+
                     break;
             }
         }
 
         if (count($this->arguments[PHPUnit_Parallel_TestRunner::PARALLEL_ARG]) == 0) {
             unset($this->arguments[PHPUnit_Parallel_TestRunner::PARALLEL_ARG]);
-        } else if (count($this->arguments[PHPUnit_Parallel_TestRunner::PARALLEL_ARG]) != 2) {
+        } elseif (count($this->arguments[PHPUnit_Parallel_TestRunner::PARALLEL_ARG]) != 2) {
             throw new RuntimeException('Both --current-node and --total-nodes are required for parallelism');
         }
 
@@ -72,7 +74,7 @@ class PHPUnit_Parallel_Command extends Command
     {
         parent::showHelp();
 
-        print <<<EOT
+        echo <<<'EOT'
 
 Parallel Options:
 

--- a/src/ParallelUI/PHPUnit_Parallel_TestRunner.php
+++ b/src/ParallelUI/PHPUnit_Parallel_TestRunner.php
@@ -10,7 +10,7 @@ use PHPUnit\TextUI\TestRunner;
 use ReflectionClass;
 
 /**
- * A Parallel test runner for CLI
+ * A Parallel test runner for CLI.
  */
 class PHPUnit_Parallel_TestRunner extends TestRunner
 {
@@ -19,8 +19,8 @@ class PHPUnit_Parallel_TestRunner extends TestRunner
     /**
      * Processes a potentially nested test suite based on various filters through the CLI.
      *
-     * @param  TestSuite $suite     The suite to filter
-     * @param  array     $arguments The CLI arguments
+     * @param  TestSuite            $suite     The suite to filter
+     * @param  array                $arguments The CLI arguments
      * @throws \ReflectionException When an error occurred at accessing the class filters.
      */
     private function processSuiteFilters(TestSuite $suite, array $arguments): void

--- a/src/ParallelUI/PHPUnit_Parallel_TestRunner.php
+++ b/src/ParallelUI/PHPUnit_Parallel_TestRunner.php
@@ -1,5 +1,12 @@
 <?php namespace PHPUnit\ParallelRunner;
 
+use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestResult;
+use PHPUnit\Framework\TestSuite;
+use PHPUnit\Runner\Filter\ExcludeGroupFilterIterator;
+use PHPUnit\Runner\Filter\Factory;
+use PHPUnit\Runner\Filter\IncludeGroupFilterIterator;
+use PHPUnit\TextUI\TestRunner;
 use PHPUnit_Runner_Filter_Factory;
 use PHPUnit_TextUI_TestRunner;
 use PHPUnit_Framework_Test;
@@ -9,17 +16,17 @@ use ReflectionClass;
 /**
  * A Parallel test runner for CLI
  */
-class PHPUnit_Parallel_TestRunner extends PHPUnit_TextUI_TestRunner
+class PHPUnit_Parallel_TestRunner extends TestRunner
 {
     const PARALLEL_ARG = 'parallelNodes';
 
     /**
      * Processes a potentially nested test suite based on various filters through the CLI.
      *
-     * @param PHPUnit_Framework_TestSuite $suite     The suite to filter
+     * @param TestSuite $suite     The suite to filter
      * @param array                       $arguments The CLI arguments
      */
-    private function processSuiteFilters(PHPUnit_Framework_TestSuite $suite, array $arguments)
+    private function processSuiteFilters(TestSuite $suite, array $arguments)
     {
         if (empty($arguments['filter']) &&
             empty($arguments[self::PARALLEL_ARG]) &&
@@ -28,18 +35,18 @@ class PHPUnit_Parallel_TestRunner extends PHPUnit_TextUI_TestRunner
             return;
         }
 
-        $filterFactory = new PHPUnit_Runner_Filter_Factory();
+        $filterFactory = new Factory();
 
         if (!empty($arguments['excludeGroups'])) {
             $filterFactory->addFilter(
-                new ReflectionClass('PHPUnit_Runner_Filter_Group_Exclude'),
+                new ReflectionClass(ExcludeGroupFilterIterator::class),
                 $arguments['excludeGroups']
             );
         }
 
         if (!empty($arguments['groups'])) {
             $filterFactory->addFilter(
-                new ReflectionClass('PHPUnit_Runner_Filter_Group_Include'),
+                new ReflectionClass(IncludeGroupFilterIterator::class),
                 $arguments['groups']
             );
         }
@@ -64,7 +71,7 @@ class PHPUnit_Parallel_TestRunner extends PHPUnit_TextUI_TestRunner
     /**
      * {@inheritdoc}
      */
-    public function doRun(PHPUnit_Framework_Test $suite, array $arguments = [], $exit = true)
+    public function doRun(Test $suite, array $arguments = [], bool $exit = true): TestResult
     {
         $this->processSuiteFilters($suite, $arguments);
 

--- a/src/ParallelUI/PHPUnit_Parallel_TestRunner.php
+++ b/src/ParallelUI/PHPUnit_Parallel_TestRunner.php
@@ -7,10 +7,6 @@ use PHPUnit\Runner\Filter\ExcludeGroupFilterIterator;
 use PHPUnit\Runner\Filter\Factory;
 use PHPUnit\Runner\Filter\IncludeGroupFilterIterator;
 use PHPUnit\TextUI\TestRunner;
-use PHPUnit_Runner_Filter_Factory;
-use PHPUnit_TextUI_TestRunner;
-use PHPUnit_Framework_Test;
-use PHPUnit_Framework_TestSuite;
 use ReflectionClass;
 
 /**
@@ -23,10 +19,11 @@ class PHPUnit_Parallel_TestRunner extends TestRunner
     /**
      * Processes a potentially nested test suite based on various filters through the CLI.
      *
-     * @param TestSuite $suite     The suite to filter
-     * @param array                       $arguments The CLI arguments
+     * @param  TestSuite $suite     The suite to filter
+     * @param  array     $arguments The CLI arguments
+     * @throws \ReflectionException When an error occurred at accessing the class filters.
      */
-    private function processSuiteFilters(TestSuite $suite, array $arguments)
+    private function processSuiteFilters(TestSuite $suite, array $arguments): void
     {
         if (empty($arguments['filter']) &&
             empty($arguments[self::PARALLEL_ARG]) &&

--- a/src/ParallelUI/PHPUnit_Parallel_TestRunner.php
+++ b/src/ParallelUI/PHPUnit_Parallel_TestRunner.php
@@ -20,8 +20,8 @@ class PHPUnit_Parallel_TestRunner extends TestRunner
     /**
      * Processes a potentially nested test suite based on various filters through the CLI.
      *
-     * @param  TestSuite            $suite     The suite to filter
-     * @param  array                $arguments The CLI arguments
+     * @param  TestSuite           $suite     The suite to filter
+     * @param  array               $arguments The CLI arguments
      * @throws ReflectionException When an error occurred at accessing the class filters.
      */
     private function processSuiteFilters(TestSuite $suite, array $arguments): void

--- a/src/ParallelUI/PHPUnit_Parallel_TestRunner.php
+++ b/src/ParallelUI/PHPUnit_Parallel_TestRunner.php
@@ -8,6 +8,7 @@ use PHPUnit\Runner\Filter\Factory;
 use PHPUnit\Runner\Filter\IncludeGroupFilterIterator;
 use PHPUnit\TextUI\TestRunner;
 use ReflectionClass;
+use ReflectionException;
 
 /**
  * A Parallel test runner for CLI.
@@ -21,7 +22,7 @@ class PHPUnit_Parallel_TestRunner extends TestRunner
      *
      * @param  TestSuite            $suite     The suite to filter
      * @param  array                $arguments The CLI arguments
-     * @throws \ReflectionException When an error occurred at accessing the class filters.
+     * @throws ReflectionException When an error occurred at accessing the class filters.
      */
     private function processSuiteFilters(TestSuite $suite, array $arguments): void
     {

--- a/tests/ParallelUI/CommandTest.php
+++ b/tests/ParallelUI/CommandTest.php
@@ -1,13 +1,13 @@
 <?php namespace PHPunit\ParallelRunner\Tests;
 
 use Exception;
+use PHPUnit\Framework\TestCase;
 use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
 use PHPUnit\ParallelRunner\PHPUnit_Parallel_TestRunner;
-use PHPUnit_Framework_TestCase;
 use ReflectionClass;
 use RuntimeException;
 
-class CommandTest extends PHPUnit_Framework_TestCase {
+class CommandTest extends TestCase {
     /**
      * @param $class
      * @param $method

--- a/tests/ParallelUI/CommandTest.php
+++ b/tests/ParallelUI/CommandTest.php
@@ -17,12 +17,11 @@ class CommandTest extends TestCase
     /**
      * Access the hidden method and make it accessible for the test.
      *
-     * @param string $class         String with the class name
-     * @param string $method        String with the method name.
-     * @throws ReflectionException  When the class or function name cannot be found/accessed.
+     * @param  string              $class  String with the class name
+     * @param  string              $method String with the method name.
+     * @throws ReflectionException When the class or function name cannot be found/accessed.
      *
      * @return ReflectionMethod
-     *
      */
     private function getHiddenMethod(string $class, string $method): ReflectionMethod
     {
@@ -36,13 +35,14 @@ class CommandTest extends TestCase
     /**
      * Gets and return the stdOut output.
      *
-     * @param callable $trigger
+     * @param  callable $trigger
      * @return string
      */
     private function getStdOut(callable $trigger): string
     {
         ob_start();
         $trigger();
+
         return ob_get_clean();
     }
 
@@ -94,8 +94,8 @@ class CommandTest extends TestCase
      * Tests assert the command would fail when both parameters are not provided.
      *
      * @dataProvider singleParameterProvider The helper function used to get the information for tests.
-     * @param        array $args             Arguments used for the test.
-     * @throws       ReflectionException     When the class or function name cannot be found/accessed.
+     * @param  array               $args Arguments used for the test.
+     * @throws ReflectionException When the class or function name cannot be found/accessed.
      */
     public function testCmdFailsWhenBothParamsAreNotProvided(array $args): void
     {

--- a/tests/ParallelUI/CommandTest.php
+++ b/tests/ParallelUI/CommandTest.php
@@ -5,15 +5,27 @@ use PHPUnit\Framework\TestCase;
 use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
 use PHPUnit\ParallelRunner\PHPUnit_Parallel_TestRunner;
 use ReflectionClass;
+use ReflectionException;
+use ReflectionMethod;
 use RuntimeException;
 
-class CommandTest extends TestCase {
+/**
+ * Class CommandTest, contains tests related to the instantiation and execution of the parallel runner.
+ */
+class CommandTest extends TestCase
+{
     /**
-     * @param $class
-     * @param $method
-     * @return \ReflectionMethod
+     * Access the hidden method and make it accessible for the test.
+     *
+     * @param string $class         String with the class name
+     * @param string $method        String with the method name.
+     * @throws ReflectionException  When the class or function name cannot be found/accessed.
+     *
+     * @return ReflectionMethod
+     *
      */
-    private function getHiddenMethod($class, $method) {
+    private function getHiddenMethod(string $class, string $method): ReflectionMethod
+    {
         $r = new ReflectionClass($class);
         $f = $r->getMethod($method);
         $f->setAccessible(true);
@@ -22,41 +34,42 @@ class CommandTest extends TestCase {
     }
 
     /**
+     * Gets and return the stdOut output.
+     *
      * @param callable $trigger
      * @return string
      */
-    private function getStdOut(callable $trigger) {
-        // start output buffering
+    private function getStdOut(callable $trigger): string
+    {
         ob_start();
-
-        // display the help
         $trigger();
-
-        // capture the output
-        $output = ob_get_contents();
-
-        // clean the stdout buffer
-        ob_end_clean();
-
-        return $output;
+        return ob_get_clean();
     }
 
     /**
+     * Tests and assert the correct creation of an instance of the runner.
      *
+     * @throws ReflectionException When the class or function name cannot be found/accessed.
      */
-    public function testCreateRunnerReturnsParallelRunner() {
+    public function testCreateRunnerReturnsParallelRunner(): void
+    {
         $cmd = new PHPUnit_Parallel_Command();
         $f = $this->getHiddenMethod(get_class($cmd), 'createRunner');
 
         $this->assertInstanceOf(PHPUnit_Parallel_TestRunner::class, $f->invokeArgs($cmd, []));
     }
 
-    public function testHelpShowsParallelParameters()
+    /**
+     * Tests and assert the correct display/return of the current options for the command showHelp.
+     *
+     * @throws ReflectionException When the class or function name cannot be found/accessed.
+     */
+    public function testHelpShowsParallelParameters(): void
     {
         $cmd = new PHPUnit_Parallel_Command();
         $f = $this->getHiddenMethod(get_class($cmd), 'showHelp');
 
-        $help = $this->getStdOut(function() use ($cmd, $f) {
+        $help = $this->getStdOut(function () use ($cmd, $f) {
             $f->invokeArgs($cmd, []);
         });
 
@@ -65,9 +78,12 @@ class CommandTest extends TestCase {
     }
 
     /**
+     * Return the data for the tests.
+     *
      * @return array
      */
-    public function singleParameterProvider() {
+    public function singleParameterProvider(): array
+    {
         return [
             [['--current-node=0']],
             [['--total-nodes=1']],
@@ -75,9 +91,14 @@ class CommandTest extends TestCase {
     }
 
     /**
-     * @dataProvider singleParameterProvider
+     * Tests assert the command would fail when both parameters are not provided.
+     *
+     * @dataProvider singleParameterProvider The helper function used to get the information for tests.
+     * @param        array $args             Arguments used for the test.
+     * @throws       ReflectionException     When the class or function name cannot be found/accessed.
      */
-    public function testCmdFailsWhenBothParamsAreNotProvided($args) {
+    public function testCmdFailsWhenBothParamsAreNotProvided(array $args): void
+    {
         $cmd = new PHPUnit_Parallel_Command();
         $f = $this->getHiddenMethod(get_class($cmd), 'handleArguments');
 

--- a/tests/Printer/TapPrinter.php
+++ b/tests/Printer/TapPrinter.php
@@ -1,0 +1,251 @@
+<?php namespace CustomPrinter;
+
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestFailure;
+use PHPUnit\Framework\TestListener;
+use PHPUnit\Framework\TestSuite;
+use PHPUnit\Framework\Warning;
+use PHPUnit\TextUI\TestRunner;
+use PHPUnit\Util\Printer;
+use Symfony\Component\Yaml\Dumper;
+use Throwable;
+
+class TapPrinter extends Printer implements TestListener
+{
+
+    /**
+     * @var int
+     */
+    protected $testNumber = 0;
+
+    /**
+     * @var int
+     */
+    protected $testSuiteLevel = 0;
+
+    /**
+     * @var bool
+     */
+    protected $testSuccessful = true;
+
+    /**
+     * @var int
+     */
+    protected $warningCount = 0;
+
+
+    public function __construct($out = null)
+    {
+        parent::__construct($out);
+        $this->write("TAP version 13\n");
+
+    }
+
+
+    /**
+     * An error occurred.
+     * @param Test $test
+     * @param Throwable $t
+     * @param float $time
+     */
+    public function addError(Test $test, Throwable $t, float $time): void
+    {
+        $this->writeNotOk($test, 'Error');
+    }
+
+    /**
+     * A warning occurred.
+     * @param Test $test
+     * @param Warning $e
+     * @param float $time
+     */
+    public function addWarning(Test $test, Warning $e, float $time): void
+    {
+        $this->warningCount++;
+    }
+
+    /**
+     * A failure occurred.
+     * @param Test $test
+     * @param AssertionFailedError $e
+     * @param float $time
+     */
+    public function addFailure(Test $test, AssertionFailedError $e, float $time): void
+    {
+        $this->writeNotOk($test, 'Failure');
+
+        $message = explode(
+            "\n",
+            TestFailure::exceptionToString($e)
+        );
+
+        $diagnostic = array(
+            'message' => $message[0],
+            'severity' => 'fail'
+        );
+
+        if ($e instanceof ExpectationFailedException) {
+            $cf = $e->getComparisonFailure();
+
+            if ($cf !== null) {
+                $diagnostic['data'] = array(
+                    'got' => $cf->getActual(),
+                    'expected' => $cf->getExpected()
+                );
+            }
+        }
+        $yaml = new Dumper();
+
+        $this->write(
+            sprintf(
+                "  ---\n%s  ...\n",
+                $yaml->dump($diagnostic, 2, 2)
+            )
+        );
+    }
+
+    /**
+     * Incomplete test.
+     * @param Test $test
+     * @param Throwable $t
+     * @param float $time
+     */
+    public function addIncompleteTest(Test $test, Throwable $t, float $time): void
+    {
+        $this->writeNotOk($test, '', 'TODO Incomplete Test');
+    }
+
+    /**
+     * Risky test.
+     * @param Test $test
+     * @param Throwable $t
+     * @param float $time
+     */
+    public function addRiskyTest(Test $test, Throwable $t, float $time): void
+    {
+        $this->write(
+            sprintf(
+                "ok %d - # RISKY%s\n",
+                $this->testNumber,
+                $t->getMessage() != '' ? ' ' . $t->getMessage() : ''
+            )
+        );
+
+        $this->testSuccessful = false;
+    }
+
+    /**
+     * Skipped test.
+     * @param Test $test
+     * @param Throwable $t
+     * @param float $time
+     */
+    public function addSkippedTest(Test $test, Throwable $t, float $time): void
+    {
+        $this->write(
+            sprintf(
+                "ok %d - # SKIP%s\n",
+                $this->testNumber,
+                $t->getMessage() != '' ? ' ' . $t->getMessage() : ''
+            )
+        );
+
+        $this->testSuccessful = false;
+    }
+
+    /**
+     * A test suite started.
+     * @param TestSuite $suite
+     */
+    public function startTestSuite(TestSuite $suite): void
+    {
+        $this->testSuiteLevel++;
+    }
+
+    /**
+     * A test suite ended.
+     * @param TestSuite $suite
+     */
+    public function endTestSuite(TestSuite $suite): void
+    {
+        $this->testSuiteLevel--;
+
+        if ($this->testSuiteLevel === 0) {
+            $this->write(sprintf("1..%d\n", $this->testNumber));
+        }
+    }
+
+    /**
+     * A test started.
+     * @param Test $test
+     */
+    public function startTest(Test $test): void
+    {
+        $this->testNumber++;
+        $this->testSuccessful = true;
+    }
+
+    /**
+     * A test ended.
+     * @param Test $test
+     * @param float $time
+     */
+    public function endTest(Test $test, float $time): void
+    {
+        if ($this->testSuccessful === true) {
+            $this->write(
+                sprintf(
+                    "ok %d - %s\n",
+                    $this->testNumber,
+                    \PHPUnit\Util\Test::describeAsString($test)
+                )
+            );
+        }
+
+        $this->writeDiagnostics($test);
+    }
+
+    /**
+     * @param Test $test
+     * @param string $prefix
+     * @param string $directive
+     */
+    protected function writeNotOk(Test $test, $prefix = '', $directive = '')
+    {
+        $this->write(
+            sprintf(
+                "not ok %d - %s%s%s\n",
+                $this->testNumber,
+                $prefix != '' ? $prefix . ': ' : '',
+                \PHPUnit\Util\Test::describe($test),
+                $directive != '' ? ' # ' . $directive : ''
+            )
+        );
+
+        $this->testSuccessful = false;
+    }
+
+
+    private function writeDiagnostics(Test $test)
+    {
+        if (!$test instanceof TestCase) {
+            return;
+        }
+
+        if (!$test->hasOutput()) {
+            return;
+        }
+
+        foreach (explode("\n", trim($test->getActualOutput())) as $line) {
+            $this->write(
+                sprintf(
+                    "# %s\n",
+                    $line
+                )
+            );
+        }
+    }
+}

--- a/tests/Printer/TapPrinter.php
+++ b/tests/Printer/TapPrinter.php
@@ -1,4 +1,6 @@
-<?php namespace CustomPrinter;
+<?php declare(strict_types=1);
+
+namespace CustomPrinter;
 
 use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\ExpectationFailedException;
@@ -29,16 +31,6 @@ class TapPrinter extends Printer implements TestListener
 
     /** @var int Amount of warnings in the current test execution. */
     protected $warningCount = 0;
-
-    /**
-     * TapPrinter constructor.
-     *
-     * @param null|mixed $out
-     */
-    public function __construct($out = null)
-    {
-        parent::__construct($out);
-    }
 
     /**
      * Adds an error to the output when an error occurred.

--- a/tests/Printer/TapPrinter.php
+++ b/tests/Printer/TapPrinter.php
@@ -8,7 +8,6 @@ use PHPUnit\Framework\TestFailure;
 use PHPUnit\Framework\TestListener;
 use PHPUnit\Framework\TestSuite;
 use PHPUnit\Framework\Warning;
-use PHPUnit\TextUI\TestRunner;
 use PHPUnit\Util\Printer;
 use Symfony\Component\Yaml\Dumper;
 use Throwable;

--- a/tests/Printer/TapPrinter.php
+++ b/tests/Printer/TapPrinter.php
@@ -134,7 +134,7 @@ class TapPrinter extends Printer implements TestListener
     /**
      * A test suite started their execution.
      *
-     * @param TestSuite $suite
+     * @param TestSuite $suite The current test suite which is going to been executed.
      */
     public function startTestSuite(TestSuite $suite): void
     {

--- a/tests/Printer/TapPrinter.php
+++ b/tests/Printer/TapPrinter.php
@@ -40,7 +40,6 @@ class TapPrinter extends Printer implements TestListener
         parent::__construct($out);
     }
 
-
     /**
      * Adds an error to the output when an error occurred.
      *
@@ -79,8 +78,8 @@ class TapPrinter extends Printer implements TestListener
         $message = explode("\n", TestFailure::exceptionToString($e));
 
         $diagnostic = [
-            'message' => $message[0],
-            'severity' => 'fail'
+            'message'  => $message[0],
+            'severity' => 'fail',
         ];
 
         if ($e instanceof ExpectationFailedException) {
@@ -88,8 +87,8 @@ class TapPrinter extends Printer implements TestListener
 
             if ($cf !== null) {
                 $diagnostic['data'] = [
-                    'got' => $cf->getActual(),
-                    'expected' => $cf->getExpected()
+                    'got'      => $cf->getActual(),
+                    'expected' => $cf->getExpected(),
                 ];
             }
         }

--- a/tests/Runner/Filter/ParallelTest_basic.phpt
+++ b/tests/Runner/Filter/ParallelTest_basic.phpt
@@ -6,7 +6,7 @@ use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
 
 // $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][2] = '--printer=CustomPrinter\TapPrinter';
 $_SERVER['argv'][3] = __DIR__ . '/_files/BasicTestFile.php';
 
 $dir = $_SERVER['PWD'];
@@ -16,6 +16,8 @@ PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
 TAP version %s
+PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+
 ok 1 - BasicTest::testBasic1
 ok 2 - BasicTest::testBasic2
 ok 3 - BasicTest::testBasic3

--- a/tests/Runner/Filter/ParallelTest_basic.phpt
+++ b/tests/Runner/Filter/ParallelTest_basic.phpt
@@ -15,7 +15,6 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-TAP version %s
 PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic1

--- a/tests/Runner/Filter/ParallelTest_error.phpt
+++ b/tests/Runner/Filter/ParallelTest_error.phpt
@@ -21,5 +21,5 @@ try {
 }
 
 --EXPECTF--
-TAP version %s
+
 Current node must be greater than or equal to 0, but less than or equal to total nodes!

--- a/tests/Runner/Filter/ParallelTest_error.phpt
+++ b/tests/Runner/Filter/ParallelTest_error.phpt
@@ -6,7 +6,7 @@ use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
 
 // $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][2] = '--printer=CustomPrinter\TapPrinter';
 $_SERVER['argv'][3] = '--current-node=1';
 $_SERVER['argv'][4] = '--total-nodes=1';
 $_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';

--- a/tests/Runner/Filter/ParallelTest_variation_node2-1.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node2-1.phpt
@@ -6,7 +6,7 @@ use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
 
 // $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][2] = '--printer=CustomPrinter\TapPrinter';
 $_SERVER['argv'][3] = '--current-node=0';
 $_SERVER['argv'][4] = '--total-nodes=2';
 $_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
@@ -18,6 +18,8 @@ PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
 TAP version %s
+PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+
 ok 1 - BasicTest::testBasic1
 ok 2 - BasicTest::testBasic3
 ok 3 - BasicTest::testBasic5

--- a/tests/Runner/Filter/ParallelTest_variation_node2-1.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node2-1.phpt
@@ -17,7 +17,6 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-TAP version %s
 PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic1

--- a/tests/Runner/Filter/ParallelTest_variation_node2-2.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node2-2.phpt
@@ -6,7 +6,7 @@ use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
 
 // $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][2] = '--printer=CustomPrinter\TapPrinter';
 $_SERVER['argv'][3] = '--current-node=1';
 $_SERVER['argv'][4] = '--total-nodes=2';
 $_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
@@ -18,6 +18,8 @@ PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
 TAP version %s
+PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+
 ok 1 - BasicTest::testBasic2
 ok 2 - BasicTest::testBasic4
 ok 3 - BasicTest::testBasic6

--- a/tests/Runner/Filter/ParallelTest_variation_node2-2.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node2-2.phpt
@@ -17,7 +17,6 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-TAP version %s
 PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic2

--- a/tests/Runner/Filter/ParallelTest_variation_node3-1.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node3-1.phpt
@@ -6,7 +6,7 @@ use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
 
 // $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][2] = '--printer=CustomPrinter\TapPrinter';
 $_SERVER['argv'][3] = '--current-node=0';
 $_SERVER['argv'][4] = '--total-nodes=3';
 $_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
@@ -18,6 +18,8 @@ PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
 TAP version %s
+PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+
 ok 1 - BasicTest::testBasic1
 ok 2 - BasicTest::testBasic4
 ok 3 - BasicTest::testBasic7

--- a/tests/Runner/Filter/ParallelTest_variation_node3-1.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node3-1.phpt
@@ -17,7 +17,6 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-TAP version %s
 PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic1

--- a/tests/Runner/Filter/ParallelTest_variation_node3-2.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node3-2.phpt
@@ -6,7 +6,7 @@ use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
 
 // $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][2] = '--printer=CustomPrinter\TapPrinter';
 $_SERVER['argv'][3] = '--current-node=1';
 $_SERVER['argv'][4] = '--total-nodes=3';
 $_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
@@ -18,6 +18,8 @@ PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
 TAP version %s
+PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+
 ok 1 - BasicTest::testBasic2
 ok 2 - BasicTest::testBasic5
 ok 3 - BasicTest::testBasic8

--- a/tests/Runner/Filter/ParallelTest_variation_node3-2.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node3-2.phpt
@@ -17,7 +17,6 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-TAP version %s
 PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic2

--- a/tests/Runner/Filter/ParallelTest_variation_node3-3.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node3-3.phpt
@@ -17,7 +17,6 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-TAP version %s
 PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic3

--- a/tests/Runner/Filter/ParallelTest_variation_node3-3.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node3-3.phpt
@@ -6,7 +6,7 @@ use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
 
 // $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][2] = '--printer=CustomPrinter\TapPrinter';
 $_SERVER['argv'][3] = '--current-node=2';
 $_SERVER['argv'][4] = '--total-nodes=3';
 $_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
@@ -18,6 +18,8 @@ PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
 TAP version %s
+PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+
 ok 1 - BasicTest::testBasic3
 ok 2 - BasicTest::testBasic6
 ok 3 - BasicTest::testBasic9

--- a/tests/Runner/Filter/ParallelTest_variation_node5-1.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node5-1.phpt
@@ -6,7 +6,7 @@ use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
 
 // $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][2] = '--printer=CustomPrinter\TapPrinter';
 $_SERVER['argv'][3] = '--current-node=0';
 $_SERVER['argv'][4] = '--total-nodes=5';
 $_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
@@ -18,6 +18,8 @@ PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
 TAP version %s
+PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+
 ok 1 - BasicTest::testBasic1
 ok 2 - BasicTest::testBasic6
 ok 3 - BasicTest::testBasic11

--- a/tests/Runner/Filter/ParallelTest_variation_node5-1.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node5-1.phpt
@@ -17,7 +17,6 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-TAP version %s
 PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic1

--- a/tests/Runner/Filter/ParallelTest_variation_node5-2.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node5-2.phpt
@@ -6,7 +6,7 @@ use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
 
 // $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][2] = '--printer=CustomPrinter\TapPrinter';
 $_SERVER['argv'][3] = '--current-node=1';
 $_SERVER['argv'][4] = '--total-nodes=5';
 $_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
@@ -18,6 +18,8 @@ PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
 TAP version %s
+PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+
 ok 1 - BasicTest::testBasic2
 ok 2 - BasicTest::testBasic7
 ok 3 - BasicTest::testBasic12

--- a/tests/Runner/Filter/ParallelTest_variation_node5-2.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node5-2.phpt
@@ -17,7 +17,6 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-TAP version %s
 PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic2

--- a/tests/Runner/Filter/ParallelTest_variation_node5-3.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node5-3.phpt
@@ -17,7 +17,6 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-TAP version %s
 PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic3

--- a/tests/Runner/Filter/ParallelTest_variation_node5-3.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node5-3.phpt
@@ -6,7 +6,7 @@ use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
 
 // $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][2] = '--printer=CustomPrinter\TapPrinter';
 $_SERVER['argv'][3] = '--current-node=2';
 $_SERVER['argv'][4] = '--total-nodes=5';
 $_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
@@ -18,6 +18,8 @@ PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
 TAP version %s
+PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+
 ok 1 - BasicTest::testBasic3
 ok 2 - BasicTest::testBasic8
 1..2

--- a/tests/Runner/Filter/ParallelTest_variation_node5-4.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node5-4.phpt
@@ -6,7 +6,7 @@ use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
 
 // $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][2] = '--printer=CustomPrinter\TapPrinter';
 $_SERVER['argv'][3] = '--current-node=3';
 $_SERVER['argv'][4] = '--total-nodes=5';
 $_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
@@ -18,6 +18,8 @@ PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
 TAP version %s
+PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+
 ok 1 - BasicTest::testBasic4
 ok 2 - BasicTest::testBasic9
 1..2

--- a/tests/Runner/Filter/ParallelTest_variation_node5-4.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node5-4.phpt
@@ -17,7 +17,6 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-TAP version %s
 PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic4

--- a/tests/Runner/Filter/ParallelTest_variation_node5-5.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node5-5.phpt
@@ -6,7 +6,7 @@ use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
 
 // $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][2] = '--printer=CustomPrinter\TapPrinter';
 $_SERVER['argv'][3] = '--current-node=4';
 $_SERVER['argv'][4] = '--total-nodes=5';
 $_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
@@ -18,6 +18,8 @@ PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
 TAP version %s
+PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+
 ok 1 - BasicTest::testBasic5
 ok 2 - BasicTest::testBasic10
 1..2

--- a/tests/Runner/Filter/ParallelTest_variation_node5-5.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node5-5.phpt
@@ -17,7 +17,6 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-TAP version %s
 PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic5

--- a/tests/Runner/Filter/ParallelTest_variation_node7-1.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-1.phpt
@@ -17,7 +17,6 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-TAP version %s
 PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic1

--- a/tests/Runner/Filter/ParallelTest_variation_node7-1.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-1.phpt
@@ -6,7 +6,7 @@ use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
 
 // $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][2] = '--printer=CustomPrinter\TapPrinter';
 $_SERVER['argv'][3] = '--current-node=0';
 $_SERVER['argv'][4] = '--total-nodes=7';
 $_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
@@ -18,6 +18,8 @@ PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
 TAP version %s
+PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+
 ok 1 - BasicTest::testBasic1
 ok 2 - BasicTest::testBasic8
 1..2

--- a/tests/Runner/Filter/ParallelTest_variation_node7-2.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-2.phpt
@@ -6,7 +6,7 @@ use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
 
 // $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][2] = '--printer=CustomPrinter\TapPrinter';
 $_SERVER['argv'][3] = '--current-node=1';
 $_SERVER['argv'][4] = '--total-nodes=7';
 $_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
@@ -18,6 +18,8 @@ PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
 TAP version %s
+PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+
 ok 1 - BasicTest::testBasic2
 ok 2 - BasicTest::testBasic9
 1..2

--- a/tests/Runner/Filter/ParallelTest_variation_node7-2.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-2.phpt
@@ -17,7 +17,6 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-TAP version %s
 PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic2

--- a/tests/Runner/Filter/ParallelTest_variation_node7-3.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-3.phpt
@@ -6,7 +6,7 @@ use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
 
 // $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][2] = '--printer=CustomPrinter\TapPrinter';
 $_SERVER['argv'][3] = '--current-node=2';
 $_SERVER['argv'][4] = '--total-nodes=7';
 $_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
@@ -18,6 +18,8 @@ PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
 TAP version %s
+PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+
 ok 1 - BasicTest::testBasic3
 ok 2 - BasicTest::testBasic10
 1..2

--- a/tests/Runner/Filter/ParallelTest_variation_node7-3.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-3.phpt
@@ -17,7 +17,6 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-TAP version %s
 PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic3

--- a/tests/Runner/Filter/ParallelTest_variation_node7-4.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-4.phpt
@@ -17,7 +17,6 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-TAP version %s
 PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic4

--- a/tests/Runner/Filter/ParallelTest_variation_node7-4.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-4.phpt
@@ -6,7 +6,7 @@ use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
 
 // $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][2] = '--printer=CustomPrinter\TapPrinter';
 $_SERVER['argv'][3] = '--current-node=3';
 $_SERVER['argv'][4] = '--total-nodes=7';
 $_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
@@ -18,6 +18,8 @@ PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
 TAP version %s
+PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+
 ok 1 - BasicTest::testBasic4
 ok 2 - BasicTest::testBasic11
 1..2

--- a/tests/Runner/Filter/ParallelTest_variation_node7-5.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-5.phpt
@@ -17,7 +17,6 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-TAP version %s
 PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic5

--- a/tests/Runner/Filter/ParallelTest_variation_node7-5.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-5.phpt
@@ -6,7 +6,7 @@ use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
 
 // $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][2] = '--printer=CustomPrinter\TapPrinter';
 $_SERVER['argv'][3] = '--current-node=4';
 $_SERVER['argv'][4] = '--total-nodes=7';
 $_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
@@ -18,6 +18,8 @@ PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
 TAP version %s
+PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+
 ok 1 - BasicTest::testBasic5
 ok 2 - BasicTest::testBasic12
 1..2

--- a/tests/Runner/Filter/ParallelTest_variation_node7-6.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-6.phpt
@@ -17,7 +17,6 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-TAP version %s
 PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic6

--- a/tests/Runner/Filter/ParallelTest_variation_node7-6.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-6.phpt
@@ -6,7 +6,7 @@ use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
 
 // $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][2] = '--printer=CustomPrinter\TapPrinter';
 $_SERVER['argv'][3] = '--current-node=5';
 $_SERVER['argv'][4] = '--total-nodes=7';
 $_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
@@ -18,5 +18,7 @@ PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
 TAP version %s
+PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+
 ok 1 - BasicTest::testBasic6
 1..1

--- a/tests/Runner/Filter/ParallelTest_variation_node7-7.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-7.phpt
@@ -17,7 +17,6 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-TAP version %s
 PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic7

--- a/tests/Runner/Filter/ParallelTest_variation_node7-7.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-7.phpt
@@ -6,7 +6,7 @@ use PHPUnit\ParallelRunner\PHPUnit_Parallel_Command;
 
 // $_SERVER['argv'][0] = 'phpunit'; // this will be set by the shell
 $_SERVER['argv'][1] = '--no-configuration';
-$_SERVER['argv'][2] = '--tap';
+$_SERVER['argv'][2] = '--printer=CustomPrinter\TapPrinter';
 $_SERVER['argv'][3] = '--current-node=6';
 $_SERVER['argv'][4] = '--total-nodes=7';
 $_SERVER['argv'][5] = __DIR__ . '/_files/BasicTestFile.php';
@@ -18,5 +18,7 @@ PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
 TAP version %s
+PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+
 ok 1 - BasicTest::testBasic7
 1..1

--- a/tests/Runner/Filter/_files/BasicTestFile.php
+++ b/tests/Runner/Filter/_files/BasicTestFile.php
@@ -1,68 +1,70 @@
 <?php
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class BasicTest.
  *
  * Long
  */
-class BasicTest extends \PHPUnit\Framework\TestCase
+class BasicTest extends TestCase
 {
-    public function testBasic1()
+    public function testBasic1(): void
     {
         $this->assertTrue(true);
     }
 
-    public function testBasic2()
+    public function testBasic2(): void
     {
         $this->assertTrue(true);
     }
 
-    public function testBasic3()
+    public function testBasic3(): void
     {
         $this->assertTrue(true);
     }
 
-    public function testBasic4()
+    public function testBasic4(): void
     {
         $this->assertTrue(true);
     }
 
-    public function testBasic5()
+    public function testBasic5(): void
     {
         $this->assertTrue(true);
     }
 
-    public function testBasic6()
+    public function testBasic6(): void
     {
         $this->assertTrue(true);
     }
 
-    public function testBasic7()
+    public function testBasic7(): void
     {
         $this->assertTrue(true);
     }
 
-    public function testBasic8()
+    public function testBasic8(): void
     {
         $this->assertTrue(true);
     }
 
-    public function testBasic9()
+    public function testBasic9(): void
     {
         $this->assertTrue(true);
     }
 
-    public function testBasic10()
+    public function testBasic10(): void
     {
         $this->assertTrue(true);
     }
 
-    public function testBasic11()
+    public function testBasic11(): void
     {
         $this->assertTrue(true);
     }
 
-    public function testBasic12()
+    public function testBasic12(): void
     {
         $this->assertTrue(true);
     }

--- a/tests/Runner/Filter/_files/BasicTestFile.php
+++ b/tests/Runner/Filter/_files/BasicTestFile.php
@@ -5,7 +5,7 @@
  *
  * Long
  */
-class BasicTest extends \PHPUnit_Framework_TestCase
+class BasicTest extends \PHPUnit\Framework\TestCase
 {
     public function testBasic1()
     {


### PR DESCRIPTION
The previous version supported (5.7) implements a custom printer option called `tap` This printer (and command line option `--tap`) was removed in the next version.

In order to upgrade other projects to newest versions of PHP and PHPUnit, is necessary to upgrade the support of this library. 

