### PR TITLE
Remove specific version from phpt tests

### DIFF
--- a/tests/Runner/Filter/ParallelTest_basic.phpt
+++ b/tests/Runner/Filter/ParallelTest_basic.phpt
@@ -15,7 +15,7 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+PHPUnit %s by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic1
 ok 2 - BasicTest::testBasic2

--- a/tests/Runner/Filter/ParallelTest_variation_node2-1.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node2-1.phpt
@@ -17,7 +17,7 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+PHPUnit %s by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic1
 ok 2 - BasicTest::testBasic3

--- a/tests/Runner/Filter/ParallelTest_variation_node2-2.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node2-2.phpt
@@ -17,7 +17,7 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+PHPUnit %s by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic2
 ok 2 - BasicTest::testBasic4

--- a/tests/Runner/Filter/ParallelTest_variation_node3-1.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node3-1.phpt
@@ -17,7 +17,7 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+PHPUnit %s by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic1
 ok 2 - BasicTest::testBasic4

--- a/tests/Runner/Filter/ParallelTest_variation_node3-2.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node3-2.phpt
@@ -17,7 +17,7 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+PHPUnit %s by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic2
 ok 2 - BasicTest::testBasic5

--- a/tests/Runner/Filter/ParallelTest_variation_node3-3.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node3-3.phpt
@@ -17,7 +17,7 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+PHPUnit %s by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic3
 ok 2 - BasicTest::testBasic6

--- a/tests/Runner/Filter/ParallelTest_variation_node5-1.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node5-1.phpt
@@ -17,7 +17,7 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+PHPUnit %s by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic1
 ok 2 - BasicTest::testBasic6

--- a/tests/Runner/Filter/ParallelTest_variation_node5-2.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node5-2.phpt
@@ -17,7 +17,7 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+PHPUnit %s by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic2
 ok 2 - BasicTest::testBasic7

--- a/tests/Runner/Filter/ParallelTest_variation_node5-3.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node5-3.phpt
@@ -17,7 +17,7 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+PHPUnit %s by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic3
 ok 2 - BasicTest::testBasic8

--- a/tests/Runner/Filter/ParallelTest_variation_node5-4.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node5-4.phpt
@@ -17,7 +17,7 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+PHPUnit %s by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic4
 ok 2 - BasicTest::testBasic9

--- a/tests/Runner/Filter/ParallelTest_variation_node5-5.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node5-5.phpt
@@ -17,7 +17,7 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+PHPUnit %s by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic5
 ok 2 - BasicTest::testBasic10

--- a/tests/Runner/Filter/ParallelTest_variation_node7-1.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-1.phpt
@@ -17,7 +17,7 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+PHPUnit %s by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic1
 ok 2 - BasicTest::testBasic8

--- a/tests/Runner/Filter/ParallelTest_variation_node7-2.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-2.phpt
@@ -17,7 +17,7 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+PHPUnit %s by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic2
 ok 2 - BasicTest::testBasic9

--- a/tests/Runner/Filter/ParallelTest_variation_node7-3.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-3.phpt
@@ -17,7 +17,7 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+PHPUnit %s by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic3
 ok 2 - BasicTest::testBasic10

--- a/tests/Runner/Filter/ParallelTest_variation_node7-4.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-4.phpt
@@ -17,7 +17,7 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+PHPUnit %s by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic4
 ok 2 - BasicTest::testBasic11

--- a/tests/Runner/Filter/ParallelTest_variation_node7-5.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-5.phpt
@@ -17,7 +17,7 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+PHPUnit %s by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic5
 ok 2 - BasicTest::testBasic12

--- a/tests/Runner/Filter/ParallelTest_variation_node7-6.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-6.phpt
@@ -17,7 +17,7 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+PHPUnit %s by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic6
 1..1

--- a/tests/Runner/Filter/ParallelTest_variation_node7-7.phpt
+++ b/tests/Runner/Filter/ParallelTest_variation_node7-7.phpt
@@ -17,7 +17,7 @@ require_once($dir . '/vendor/autoload.php');
 PHPUnit_Parallel_Command::main();
 
 --EXPECTF--
-PHPUnit 7.5.14 by Sebastian Bergmann and contributors.
+PHPUnit %s by Sebastian Bergmann and contributors.
 
 ok 1 - BasicTest::testBasic7
 1..1


### PR DESCRIPTION
Remove the specific phpunit version from the tests, so we can use different versions of phpunit without changing the tests.